### PR TITLE
Some stylistic adjustments

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -220,3 +220,7 @@ body #mc_embed_signup .button:hover {
 body #mc_embed_signup #mc-embedded-subscribe-form div.mce_inline_error {
     background-color: transparent;
 }
+
+.diag {
+    padding-bottom: 1ex;
+}


### PR DESCRIPTION
N.B. The diff is bigger that it would otherwise be, as I judiciously employed `M-x fill-paragraph`, which may make subsequent diffs easier to follow, if we're consistent.

Generally, I tried to condense things, to remove unnecessary hyphenation (append-log, etc.), avoid using mathjax for integers.  I'd suggest a couple of changes to the diagrams, if you think they make sense:

 - Including the append log region as empty rectangles in the inner nodes in the first B+ tree diagram is confusing - is it easy to remove those?
 - I think hash-labelling the edges is unnecessarily confusing in the early diagrams, and the merkle/authentication section/s will make more sense if that is the point at which the labels are introduced.
 - Not all of the labels are valid hex strings 
 - The insertion examples (e.g. `-1`, and I think the one above it) could probably do with some minimal handwritten annotation, even if it's just circling the inserted value.

I think there remain some tonal incongruities (it's not clear there exist readers unfamiliar with binary trees who will be comfortable with the details of B+ tree complexity one paragraph later).  I think we don't really explain in detail what properties an index is required to have early on, and should probably explain how exactly the pointers aid in navigation, as it is less obvious than some other points that are addressed explicitly.  I can help out with those if you're busy and don't disagree. 

I removed the section on append logs, as I think it was out of place in a series of paragraphs about different trees, and is clear enough later in context.   

Obviously feel free to reject or cherry pick - it's your post.  As before, maybe it's more helpful to read it through in the browser before trawling through the diff.